### PR TITLE
Chore: include qt download link

### DIFF
--- a/ChaosInitiative.Web.HomePage/Pages/Engine.cshtml
+++ b/ChaosInitiative.Web.HomePage/Pages/Engine.cshtml
@@ -49,7 +49,6 @@
 }
 <div class="bg-dark flex-grow-1">
     <div class="container pt-6 pb-5">
-        <!-- Move this to control panel -->
         <h1>Engine FAQ</h1>
         <hr>
         <h2 class="pt-2">Why is it not open source?</h2>
@@ -64,6 +63,16 @@
         <p>No. Due to the way source is set up and certain conditions, Chaos Source is only accessible in our games and cannot be distributed as standalone SDK. </p>
         <p>If you wish to create a single-player game with Chaos Source features, Portal 2: Community Edition would probably suit your project the best, even for non-portal mods. </p>
     
+    </div>
+</div>
+
+<div class="bg-dark flex-grow-1">
+    <div class="container pt-6 pb-5">
+        <h1>Legal Information</h1>
+        <hr>
+        <h2 class="pt-2">Qt UI</h2>
+        <p>Chaos Source uses a custom fork of the Qt UI framework for several tool applications. Qt is licensed under the LGPLv3 license, see <a href="https://doc.qt.io/qt-6/lgpl.html">this page</a> for more info.
+           Qt's source code can be obtained <a href="/qt-source/chaos-qtbase.zip">here</a> or from <a href="https://github.com/ChaosInitiative/qtbase">this GitHub repository</a>.</p>
     </div>
 </div>
 


### PR DESCRIPTION
Federal regulations require me to warn you that this ~~next test chamber~~ UI framework... is ~~looking pretty good~~ a fork of Qt and necessitates a public download link.